### PR TITLE
ngfw-15014: Removed ec2 arm jobs from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,12 +48,6 @@ env:
     - ARCHITECTURE: arm64
       TYPE: qcow2
       VENDOR: untangle
-    - ARCHITECTURE: arm64
-      TYPE: ec2/byol
-      VENDOR: untangle
-    - ARCHITECTURE: arm64
-      TYPE: ec2/payg
-      VENDOR: untangle
 
 before_install:
 - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin


### PR DESCRIPTION
Travis failed, but usually during promotion and sync as well travis fails. For building cloud images need to run the command manually after these changes are merged into master as per the document.
https://awakesecurity.atlassian.net/wiki/spaces/ngfw/pages/2075525283/CI+CD+builds
 Hence commenting out arm jobs on ec2 should cover this user story and stop building arm64 jobs on ec2