### PR TITLE
NGFW-15270 Removed qcow2 ARM build and using jammy distribution for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,10 @@ before_install:
 - chmod 600 ${SSH_KEY}
 
 script:
+  # focal-pgdg repo is moved under apt-archive.postgresql.org
+  - sudo echo "deb http://apt-archive.postgresql.org/pub/repos/apt focal-pgdg main" | sudo tee /etc/apt/sources.list.d/postgresql.list
+  # Add the official PostgreSQL repo key
+  - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
   - sudo apt update
   - sudo apt install -y qemu-user-static binfmt-support
   - docker-compose -f docker-compose.build.yml run pkgtools

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,6 @@ env:
     - ARCHITECTURE: amd64
       TYPE: azure/payg
       VENDOR: untangle
-    - ARCHITECTURE: arm64
-      TYPE: qcow2
-      VENDOR: untangle
 
 before_install:
 - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: focal
+dist: jammy
 
 if: branch =~ /^(master|((ngfw|waf)-)?release-\d+.\d)$/ AND type IN (push, cron, api) AND tag IS blank
 
@@ -56,10 +56,6 @@ before_install:
 - chmod 600 ${SSH_KEY}
 
 script:
-  # focal-pgdg repo is moved under apt-archive.postgresql.org
-  - sudo echo "deb http://apt-archive.postgresql.org/pub/repos/apt focal-pgdg main" | sudo tee /etc/apt/sources.list.d/postgresql.list
-  # Add the official PostgreSQL repo key
-  - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
   - sudo apt update
   - sudo apt install -y qemu-user-static binfmt-support
   - docker-compose -f docker-compose.build.yml run pkgtools


### PR DESCRIPTION
- As per this announcement https://www.postgresql.org/message-id/aItWGvIAWFEsLqds%40msg.df7cb.de, hence using jammy distribution for travis.
- Removed qcow2 ARM build.